### PR TITLE
Alternative design for exception translators

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -820,6 +820,55 @@ There is also a special exception :class:`cast_error` that is thrown by
 :func:`handle::call` when the input arguments cannot be converted to Python
 objects.
 
+Registering custom exception translators
+========================================
+
+If the default exception conversion described above is not sufficient, the
+additional header file :file:`pybind11/exception_translator.h` provides
+support for registering custom exception translators.
+
+The function ``pybind11::register_exception_translator(translator)`` takes
+any callable (e.g. lambda, ``std::bind`` wrapped function, or function object) with
+the following call signature: ``void(std::exception_ptr)``.
+
+When a C++ exception is thrown, registered exception translators are tried
+in reverse order of registration (i.e. the last registered translator gets
+a first shot at handling the exception).
+
+Inside the translator ``std::rethrow_exception`` should be used, within
+a try block, to re-throw the exception. A catch clause can then use
+``PyErr_SetString`` or ``PyErr_SetObject`` to set a custom Python exception
+as demonstrated in :file:`example18.cpp``.
+
+Registering a translator looks like:
+
+.. code-block:: cpp
+
+    py::register_exception_translator([](std::exception_ptr p) { 
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const MyCustomException &e) {
+            PyErr_SetString(PyExc_RuntimeError, e.what());
+        }
+    });
+
+Multiple exceptions can be handled by a single translator. If the exception
+is not caught by the current translator, the previously registered one gets a chance.
+
+If none of the registered exception translators is able to handle the exception it is handled by the default converter as described in the previous section.
+
+.. note::
+
+    You must either call ``PyErr_SetString`` or ``PyErr_SetObject``
+    for every exception caught in a custom exception translator.
+    Failure to do so will cause Python to crash with 
+    ``SystemError: error return without exception set``.
+
+    Exceptions that you do not plan to handle should simply not be caught.
+
+    You may also choose to explicity (re)throw to delegate to other
+    exception translators.
+
 .. _opaque:
 
 Treating STL data structures as opaque objects

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PYBIND11_EXAMPLES
   example15.cpp
   example16.cpp
   example17.cpp
+  example18.cpp
   issues.cpp
 )
 

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -26,6 +26,7 @@ void init_ex14(py::module &);
 void init_ex15(py::module &);
 void init_ex16(py::module &);
 void init_ex17(py::module &);
+void init_ex18(py::module &);
 void init_issues(py::module &);
 
 #if defined(PYBIND11_TEST_EIGEN)
@@ -52,6 +53,7 @@ PYBIND11_PLUGIN(example) {
     init_ex15(m);
     init_ex16(m);
     init_ex17(m);
+    init_ex18(m);
     init_issues(m);
 
     #if defined(PYBIND11_TEST_EIGEN)

--- a/example/example18.cpp
+++ b/example/example18.cpp
@@ -1,0 +1,118 @@
+/*
+    example/example9.cpp -- exception translation
+
+    Copyright (c) 2016 Pim Schellart <P.Schellart@princeton.edu
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#include "example.h"
+#include <pybind11/exception_translator.h>
+
+// A type that should be raised as an exeption in Python
+class MyError : public std::exception {
+public:
+    explicit MyError(const char * m) : message{m} {}
+    virtual const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
+// A type that should be translated to a standard Python exception
+class MyError2 : public std::exception {
+public:
+    explicit MyError2(const char * m) : message{m} {}
+    virtual const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
+// A type that is not derived from std::exception (and is thus unknown)
+class MyError3 {
+public:
+    explicit MyError3(const char * m) : message{m} {}
+    virtual const char * what() const noexcept {return message.c_str();}
+private:
+    std::string message = "";
+};
+
+// A type that should be translated to MyError1
+// and delegated to its exception translator
+class MyError4 : public std::exception {
+public:
+    explicit MyError4(const char * m) : message{m} {}
+    virtual const char * what() const noexcept override {return message.c_str();}
+private:
+    std::string message = "";
+};
+
+void something_that_throws1() {
+    throw MyError("this error should go to a custom type");
+}
+
+void something_that_throws2() {
+    throw MyError2("this error should go to a standard Python exception");
+}
+
+void something_that_throws3() {
+    throw MyError3("this error cannot be translated");
+}
+
+void something_that_throws4() {
+    throw MyError4("this error is rethrown");
+}
+
+void something_that_throws5() {
+    throw std::logic_error("this error should fall through to the standard handler");
+}
+
+void init_ex18(py::module &m) {
+    py::class_<MyError> cls(m, "MyError");
+
+    cls.def(py::init<const char *>())
+        .def("what", &MyError::what)
+        .def("__repr__", &MyError::what);
+
+    // store custom exception type MyError and register new translator
+    static auto my_exception_type = cls.ptr();
+    py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const MyError &e) {
+            // store current exception to ensure proper cleanup
+            static py::object current_exception;
+            current_exception = py::cast(MyError(e.what()));
+            PyErr_SetObject(my_exception_type, current_exception.ptr()); 
+        }
+    });
+
+    // register new translator for MyError2
+    // no need to store anything here because this type will
+    // never by visible from Python
+    py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const MyError2 &e) {
+            PyErr_SetString(PyExc_RuntimeError, e.what());
+        }
+    });
+
+    // register new translator for MyError4
+    // which will catch it and delegate to the previously registered
+    // translator for MyError1 by throwing a new exception
+    py::register_exception_translator([](std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const MyError4 &e) {
+            throw MyError(e.what());
+        }
+    });
+
+    m.def("something_that_throws1", &something_that_throws1);
+    m.def("something_that_throws2", &something_that_throws2);
+    m.def("something_that_throws3", &something_that_throws3);
+    m.def("something_that_throws4", &something_that_throws4);
+    m.def("something_that_throws5", &something_that_throws5);
+}
+

--- a/example/example18.py
+++ b/example/example18.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
+sys.path.append('.')
+
+import example
+
+try:
+    example.something_that_throws1()
+except example.MyError as e:
+    print(type(e), e)
+
+try:
+    example.something_that_throws2()
+except Exception as e:
+    print(type(e), e)
+
+try:
+    example.something_that_throws3()
+except Exception as e:
+    print(type(e), e)
+
+try:
+    example.something_that_throws4()
+except example.MyError as e:
+    print(type(e), e)
+
+try:
+    example.something_that_throws5()
+except Exception as e:
+    print(type(e), e)

--- a/example/example18.ref
+++ b/example/example18.ref
@@ -1,0 +1,5 @@
+<class 'example.MyError'> this error should go to a custom type
+<type 'exceptions.RuntimeError'> this error should go to a standard Python exception
+<type 'exceptions.RuntimeError'> Caught an unknown exception!
+<class 'example.MyError'> this error is rethrown
+<type 'exceptions.RuntimeError'> this error should fall through to the standard handler

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -30,6 +30,28 @@ struct type_info {
     void *get_buffer_data = nullptr;
 };
 
+struct default_exception_translator {
+    void operator()(std::exception_ptr p) {
+        try {
+            if (p) std::rethrow_exception(p);
+        } catch (const error_already_set &)      {                                                 return;
+        } catch (const index_error &e)           { PyErr_SetString(PyExc_IndexError,    e.what()); return;
+        } catch (const value_error &e)           { PyErr_SetString(PyExc_ValueError,    e.what()); return;
+        } catch (const stop_iteration &e)        { PyErr_SetString(PyExc_StopIteration, e.what()); return;
+        } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return;
+        } catch (const std::domain_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
+        } catch (const std::invalid_argument &e) { PyErr_SetString(PyExc_ValueError,    e.what()); return;
+        } catch (const std::length_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return;
+        } catch (const std::out_of_range &e)     { PyErr_SetString(PyExc_IndexError,    e.what()); return;
+        } catch (const std::range_error &e)      { PyErr_SetString(PyExc_ValueError,    e.what()); return;
+        } catch (const std::exception &e)        { PyErr_SetString(PyExc_RuntimeError,  e.what()); return;
+        } catch (...) {
+            PyErr_SetString(PyExc_RuntimeError, "Caught an unknown exception!");
+            return;
+        }
+    }
+};
+
 PYBIND11_NOINLINE inline internals &get_internals() {
     static internals *internals_ptr = nullptr;
     if (internals_ptr)
@@ -49,6 +71,8 @@ PYBIND11_NOINLINE inline internals &get_internals() {
             internals_ptr->istate = tstate->interp;
         #endif
         builtins[id] = capsule(internals_ptr);
+        static default_exception_translator translator;
+        internals_ptr->registered_exception_translators.push_front(translator);
     }
     return *internals_ptr;
 }

--- a/include/pybind11/common.h
+++ b/include/pybind11/common.h
@@ -66,6 +66,7 @@
 #  pragma warning(pop)
 #endif
 
+#include <forward_list>
 #include <vector>
 #include <string>
 #include <stdexcept>
@@ -262,6 +263,7 @@ struct internals {
     std::unordered_map<const void *, void*> registered_types_py;     // PyTypeObject* -> type_info
     std::unordered_map<const void *, void*> registered_instances;    // void * -> PyObject*
     std::unordered_set<std::pair<const PyObject *, const char *>, overload_hash> inactive_overload_cache;
+    std::forward_list<std::function<void(std::exception_ptr)>> registered_exception_translators;
 #if defined(WITH_THREAD)
     decltype(PyThread_create_key()) tstate = 0; // Usually an int but a long on Cygwin64 with Python 3.x
     PyInterpreterState *istate = nullptr;

--- a/include/pybind11/exception_translator.h
+++ b/include/pybind11/exception_translator.h
@@ -1,0 +1,24 @@
+/*
+    pybind11/exception_translator.h: Translators for custom exceptions
+
+    Copyright (c) 2016 Pim Schellart <P.Schellart@princeton.edu>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include "pybind11.h"
+#include <forward_list>
+#include <iostream>
+
+NAMESPACE_BEGIN(pybind11)
+
+template <typename ExceptionTranslator>
+void register_exception_translator(ExceptionTranslator&& translator) {
+    detail::get_internals().registered_exception_translators.push_front(std::forward<ExceptionTranslator>(translator));
+}
+
+NAMESPACE_END(pybind11)
+

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -394,19 +394,32 @@ protected:
                 if (result.ptr() != PYBIND11_TRY_NEXT_OVERLOAD)
                     break;
             }
-        } catch (const error_already_set &)      {                                                 return nullptr;
-        } catch (const index_error &e)           { PyErr_SetString(PyExc_IndexError,    e.what()); return nullptr;
-        } catch (const value_error &e)           { PyErr_SetString(PyExc_ValueError,    e.what()); return nullptr;
-        } catch (const stop_iteration &e)        { PyErr_SetString(PyExc_StopIteration, e.what()); return nullptr;
-        } catch (const std::bad_alloc &e)        { PyErr_SetString(PyExc_MemoryError,   e.what()); return nullptr;
-        } catch (const std::domain_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return nullptr;
-        } catch (const std::invalid_argument &e) { PyErr_SetString(PyExc_ValueError,    e.what()); return nullptr;
-        } catch (const std::length_error &e)     { PyErr_SetString(PyExc_ValueError,    e.what()); return nullptr;
-        } catch (const std::out_of_range &e)     { PyErr_SetString(PyExc_IndexError,    e.what()); return nullptr;
-        } catch (const std::range_error &e)      { PyErr_SetString(PyExc_ValueError,    e.what()); return nullptr;
-        } catch (const std::exception &e)        { PyErr_SetString(PyExc_RuntimeError,  e.what()); return nullptr;
+        } catch (const error_already_set &) {
+            return nullptr;
         } catch (...) {
-            PyErr_SetString(PyExc_RuntimeError, "Caught an unknown exception!");
+            /* When an exception is caught, give each registered exception
+               translator a chance to translate it to a Python exception
+               in reverse order of registration.
+              
+               A translator may choose to do one of the following:
+              
+                - catch the exception and call PyErr_SetString or PyErr_SetObject
+                  to set a standard (or custom) Python exception, or
+                - do nothing and let the exception fall through to the next translator, or
+                - delegate translation to the next translator by throwing a new type of exception. */
+
+            auto last_exception = std::current_exception(); 
+            auto &registered_exception_translators = pybind11::detail::get_internals().registered_exception_translators;
+            for (auto& translator : registered_exception_translators) {
+                try {
+                    translator(last_exception);
+                } catch (...) {
+                    last_exception = std::current_exception();
+                    continue;
+                }
+                return nullptr;
+            }
+            PyErr_SetString(PyExc_SystemError, "Exception escaped from default exception translator!");
             return nullptr;
         }
 


### PR DESCRIPTION
This design makes the default handing into just another exception translator which is always tried last. With this design user registered translators are no longer required to always catch all exceptions (which they may forget to do, breaking the exception translation chain). Instead they should only catch those exceptions they actually translate, leaving the rest to the next registered translator.

A downside of this design is that exception handling is perhaps less readable, because it is split up into different files and objects.
